### PR TITLE
fix: 잘못된 realmDB 사용방식 수정

### DIFF
--- a/src/RealmDB/Schema.ts
+++ b/src/RealmDB/Schema.ts
@@ -15,6 +15,7 @@ const AUTH_INFO = 'AuthInfo';
 export const authSchema = {
   name: AUTH_INFO,
   properties: {
+    _id: 'int',
     access_token: 'string',
     refresh_token: 'string',
     id_token: 'string',
@@ -23,6 +24,7 @@ export const authSchema = {
     state: 'string',
     token_type: 'string',
   },
+  primaryKey: '_id',
 };
 
 let realmInstance: Realm | null = null;
@@ -45,7 +47,7 @@ export const writeAuthInfo = async (userInfo: IAuthData): Promise<void> => {
   const realm = await authInfoRealm();
 
   realm.write(() => {
-    realm.create(AUTH_INFO, userInfo, Realm.UpdateMode.Modified);
+    realm.create(AUTH_INFO, {_id: 0, ...userInfo}, Realm.UpdateMode.Modified);
   });
 };
 
@@ -53,7 +55,9 @@ export const readAuthInfo = async (): Promise<IAuthData | undefined> => {
   try {
     const realm = await authInfoRealm();
 
-    const userData: Results<IAuthData> = realm.objects<IAuthData>(AUTH_INFO);
+    const userData: Results<IAuthData> = realm
+      .objects<IAuthData>(AUTH_INFO)
+      .filtered('_id==0');
 
     return userData ? userData[0] : undefined;
   } catch (e) {


### PR DESCRIPTION
_id 인 pk 를 주고 사용했어야 했는데 pk 를 안넣었더니 create 시 계속 새로운 access token 이 쌓였고 그중 가장 처음에 만들어진 토큰을 가져오고 있어서 _id 로 저장하고 불러오는 방식으로 변경합니다.