### PR TITLE
fix: sign in again when access token doesn't work

### DIFF
--- a/src/Screens/Login/LoginScreen.tsx
+++ b/src/Screens/Login/LoginScreen.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react-native';
 import 'react-native-url-polyfill/auto';
 import {refreshAuthInfo} from '../../Api/Login';
+import {requestUser} from '../../Api/User';
 import {RootStackParamList, RouteNames} from '../../Navigators/RouteNames';
 import {readAuthInfo} from '../../RealmDB/Schema';
 
@@ -31,7 +32,15 @@ const LoginScreen = (props: IProps): JSX.Element => {
           return;
         }
 
-        const {date, expires_in, refresh_token} = authData;
+        const {date, expires_in, refresh_token, access_token} = authData;
+        // 모종의 이유로 access token 이 유효하지 않으면 처음부터 로그인
+
+        const userData = await requestUser(access_token);
+
+        if (!userData) {
+          navigation.navigate(RouteNames.TeslaWebViewScreen);
+          return;
+        }
 
         // 만료된 경우 refresh token 을 사용
         const expireDate = dayjs(date).add(expires_in, 'seconds');


### PR DESCRIPTION
user 정보를 불러오는 api 를 가지고 있는 access token 으로 쿼리 시도 후 실패하면 access token 을 다시 가져오기 위해 테슬라 로그인 페이지로 돌아갑니다.